### PR TITLE
Adding Notch detection and taking all available space

### DIFF
--- a/iOS-UIKit-video-player/ShowCaseUIKit/Base.lproj/Main.storyboard
+++ b/iOS-UIKit-video-player/ShowCaseUIKit/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/iOS-UIKit-video-player/ShowCaseUIKit/VideoWrapper.swift
+++ b/iOS-UIKit-video-player/ShowCaseUIKit/VideoWrapper.swift
@@ -22,6 +22,12 @@ class VideoWrapper: UIView {
     webViewCoordinator.webView.scrollView.bounces = false
     webViewCoordinator.webView.scrollView.isScrollEnabled = false
     webViewCoordinator.webView.backgroundColor = .black
+      
+    // This enable webview inspection on safari console
+    if #available(iOS 16.4, *) {
+        webViewCoordinator.webView.isInspectable = true
+    }
+
     backgroundColor = .black
     addSubview(webViewCoordinator.webView)
     addSubview(customBetslip)

--- a/iOS-swiftUI-video-player/SwiftUIVideoPlayer/WebViewWrapper.swift
+++ b/iOS-swiftUI-video-player/SwiftUIVideoPlayer/WebViewWrapper.swift
@@ -8,6 +8,11 @@ struct WebViewWrapper: UIViewRepresentable {
     webView.scrollView.bounces = false
     webView.scrollView.isScrollEnabled = false
     webView.backgroundColor = .black
+    
+    // This enable webview inspection on safari console
+    if #available(iOS 16.4, *) {
+        webView.isInspectable = true
+    }
 
     return webView
   }


### PR DESCRIPTION
Adding Notch detection and taking all available space without puttin content behind notch on fullscreen.

- Adding notch detection function for UIkit and SwiftUI
- Adding padding on safe area behind the notch
- Enable webview inspectrion on Safari

![Simulator Screenshot - iPhone 16 Pro - 2025-04-09 at 16 01 16](https://github.com/user-attachments/assets/69cb1609-ade8-4edb-b9d7-91c1f6e797df)
![Simulator Screenshot - iPhone 16 Pro - 2025-04-09 at 16 03 31](https://github.com/user-attachments/assets/e4c77250-ea17-4ae9-bca2-5b553f97e61e)
